### PR TITLE
Remove "categorize" action type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,12 +134,12 @@ fn process_change(change: &Json) -> Option<Change> {
     };
     let ftitle = Title(&title);
     let (action, description, link, extra) = match kind {
-        "categorize" => (
-            "Categorize".into(),
-            format!("Updated {}", ftitle),
-            None,
-            Vec::new(),
-        ),
+        // "categorize" => (
+        //     "Categorize".into(),
+        //     format!("Updated {}", ftitle),
+        //     None,
+        //     Vec::new(),
+        // ),
         "edit" => (
             "Edit".into(),
             format!("Edited {}", ftitle),


### PR DESCRIPTION
The categorize action type tends to pollute the recent changes feed and doesn't seem helpful. This PR removes it for sake of readability of other more important actions like edits.